### PR TITLE
raised 'error' varible within scope to cover references in alternate code paths

### DIFF
--- a/shop_stripe/offsite_stripe.py
+++ b/shop_stripe/offsite_stripe.py
@@ -40,9 +40,9 @@ class StripeBackend(object):
                 'You must define the SHOP_STRIPE_PRIVATE_KEY'
                 ' and SHOP_STRIPE_PUBLISHABLE_KEY settings'
             )
+        error = None
         if request.method == 'POST':
             form = CardForm(request.POST)
-            error = None
             try:
                 card_token = request.POST['stripeToken']
             except KeyError:


### PR DESCRIPTION
The variable `error` is only created within the `if` scope, but it is referenced in the `return`. The leaves the `else` case exposed to referencing an undefined variable. 
